### PR TITLE
Set custom Status

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,11 @@
   }, {
     "separator": true
   }, {
+    "name": "Custom status…",
+    "command": "custom"
+  }, {
+    "separator": true
+  }, {
     "name": "Settings…",
     "command": "settings"
   }]

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "typescript": "^3.5.3",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"
+  },
+  "dependencies": {
+    "rxjs": "^6.5.3"
   }
 }

--- a/src/helpers/badgeForNode.ts
+++ b/src/helpers/badgeForNode.ts
@@ -7,7 +7,7 @@ interface PluginData {
 
 /**
  * Convert a JSON string into a PluginData object
- * @param encodedPluginData
+ * @param string encodedPluginData
  */
 export const decodePluginData = (
   encodedPluginData: string

--- a/src/helpers/createBadge.ts
+++ b/src/helpers/createBadge.ts
@@ -4,7 +4,7 @@ export enum Status {
   Done = "done"
 }
 
-const colorForStatus = (status: Status): RGB => {
+export const colorForStatus = (status: Status): RGB => {
   switch (status) {
     case Status.WIP:
       return { r: 235 / 255, g: 87 / 255, b: 87 / 255 };
@@ -26,7 +26,7 @@ export const textForStatus = (status: Status): string => {
   }
 };
 
-const createBadge = async (text: string, color: RGB) => {
+export const createBadge = async (text: string, color: RGB) => {
   const fontName: FontName = {
     family: "Roboto",
     style: "Bold"
@@ -79,6 +79,3 @@ const createBadge = async (text: string, color: RGB) => {
 
   return frame;
 };
-
-export const createBadgeForStatus = async (status: Status) =>
-  createBadge(textForStatus(status), colorForStatus(status));

--- a/src/helpers/next.ts
+++ b/src/helpers/next.ts
@@ -1,0 +1,2 @@
+/** Helper function to automatically create an Observer object with only a `next` value (because directly passing the `next` callback is deprecated) */
+export const next = <T>(onNext: (value: T) => void) => ({ next: onNext });

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -1,12 +1,28 @@
 const SETTINGS_KEY = "plugin-settings";
 
+export interface CustomStatus {
+  text: string;
+  color: RGB;
+}
+
 export interface PluginSettings {
   shouldGroupBadgeAndElement: boolean;
+  customStatuses: Array<CustomStatus>;
 }
 
 export const loadSettings = async (): Promise<PluginSettings> => {
   const defaults: PluginSettings = {
-    shouldGroupBadgeAndElement: false
+    shouldGroupBadgeAndElement: false,
+    customStatuses: [
+      {
+        text: "Custom",
+        color: {
+          r: 0.5,
+          g: 0.5,
+          b: 0.5
+        }
+      }
+    ]
   };
 
   try {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -41,7 +41,7 @@ function createSwitch(
   return wrapper;
 }
 
-const initUI = (settings: PluginSettings) => {
+const initSettingsUI = (settings: PluginSettings) => {
   const groupBadgeSwitch = createSwitch(
     "toggleGroupBadge",
     settings.shouldGroupBadgeAndElement,
@@ -61,6 +61,19 @@ const initUI = (settings: PluginSettings) => {
   document.body.appendChild(groupBadgeSwitch);
 };
 
+const initCustomStatusUI = (settings: PluginSettings) => {
+  settings.customStatuses.forEach(customStatus => {
+    const button = document.createElement("button");
+    button.innerText = customStatus.text;
+
+    button.addEventListener("click", () => {
+      dispatchToPlugin("set-custom-status", customStatus);
+    });
+
+    document.body.appendChild(button);
+  });
+};
+
 export interface PluginMessage {
   type: string;
   payload?: any;
@@ -70,10 +83,11 @@ onmessage = event => {
   const pluginMessage = event.data.pluginMessage as PluginMessage;
 
   switch (pluginMessage.type) {
-    case "init":
-      const settings = pluginMessage.payload.settings as PluginSettings;
-
-      initUI(settings);
+    case "init-settings":
+      initSettingsUI(pluginMessage.payload.settings as PluginSettings);
+      break;
+    case "init-custom-status":
+      initCustomStatusUI(pluginMessage.payload.settings as PluginSettings);
       break;
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "moduleResolution": "node",
     "outDir": "./dist/",
     "sourceMap": true,
     "module": "es6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rxjs@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
+  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"


### PR DESCRIPTION
Add option to set a custom Status. 

When implementing this, the event listeners and switch statements got a bit out of hand, so I decided to convert them into streams.

Ref: https://github.com/bramschulting/status-for-figma/issues/2

**Todo**
- [ ] Create editor for custom status

![](https://user-images.githubusercontent.com/1703323/65831952-1f1aed00-e2bf-11e9-941a-ea6a06c26f93.gif)